### PR TITLE
Fix: Prevent grep option misinterpretation for search terms starting with -

### DIFF
--- a/repo-grep.el
+++ b/repo-grep.el
@@ -1,7 +1,7 @@
 ;;; repo-grep.el --- Project-wide grep search -*- lexical-binding: t; -*-
 
 ;; Author:  Bjoern Hendrik Fock
-;; Version: 1.5.1
+;; Version: 1.5.2
 ;; License: BSD-3-Clause
 ;; Keywords: tools search grep convenience project
 ;; Package-Requires: ((emacs "25.1"))

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -189,6 +189,8 @@ Optional keyword arguments in ARGS:
            (input (read-string prompt nil nil symbol-at-point))
            (sanitised-input (repo-grep--sanitise-input input))
            (search-term (if (string-empty-p sanitised-input) default-term sanitised-input))
+           ;; Strip leading hyphens to avoid grep interpreting them as options
+           (search-term (replace-regexp-in-string "^[-]+" "" search-term))
            (search-pattern (concat (or left-regex "") search-term (or right-regex "")))
            (folder (repo-grep--find-folder))
            (files (split-string (repo-grep--build-file-pattern include-ext exclude-ext)))


### PR DESCRIPTION
### Summary

This PR addresses an issue where search terms beginning with a hyphen (-) were incorrectly interpreted as grep options, causing command failures or potential security concerns.

###  Details of the Change

* Added sanitisation step in repo-grep--internal:

 ```
 ;; Strip leading hyphens to avoid grep interpreting them as options
 (search-term (replace-regexp-in-string "^[\\-]+" "" search-term))
 ```

* Ensures user input like `-foo` is treated as a literal search term (foo) rather than a grep flag.
* Maintains compatibility with existing sanitisation logic for safe shell execution.

### Why This Fix Is Needed
* Bug: Searching for terms starting with `-` caused grep to fail or behave unexpectedly.
* Impact: Improved robustness and security by preventing unintended option injection.