### PR TITLE
Improve project root detection and add manual override

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For a detailed guide to all features, see the [repo-grep tutorial](docs/repo-gre
 | Respect .gitignore (rg only) | `repo-grep-rg-use-gitignore` | off | `M-x repo-grep-set-rg-use-gitignore` |
 | Multiple grep buffers | `repo-grep-new-buffer` | off | `M-x repo-grep-set-new-buffer` |
 | Restrict to subfolder | `repo-grep-subfolder` | nil | `M-x repo-grep-set-subfolder` |
+| Manual project root | `repo-grep-root` | nil | `M-x repo-grep-set-root` |
 
 All settings can also be set directly in your configuration, e.g. `(setq repo-grep-case-sensitive t)`.
 

--- a/docs/repo-grep-tutorial.md
+++ b/docs/repo-grep-tutorial.md
@@ -84,7 +84,7 @@ When you open a file inside a Git submodule, `vc-root-dir` returns the submodule
 ├── src/
 ├── docs/
 └── vendor/
-└── netcdf-fortran/   ← Git submodule, has its own .git
+   └── netcdf-fortran/   ← Git submodule, has its own .git
 ```
 
 Opening a file inside `vendor/netcdf-fortran/` and pressing `F12` searches only the submodule. Use `M-x repo-grep-set-root` to point repo-grep at the parent repository instead:

--- a/docs/repo-grep-tutorial.md
+++ b/docs/repo-grep-tutorial.md
@@ -73,6 +73,28 @@ Opening any file inside `cesm/` and pressing `C-F12` searches all three director
 
 Note that any active `repo-grep-subfolder` restriction is ignored by `repo-grep-multi` — the search always spans all sibling directories regardless.
 
+
+### Searching across a project with Git submodules
+
+When you open a file inside a Git submodule, `vc-root-dir` returns the submodule root rather than the parent repository root. Suppose your repository looks like this:
+
+```
+~/climate-model/
+├── .git/
+├── src/
+├── docs/
+└── vendor/
+└── netcdf-fortran/   ← Git submodule, has its own .git
+```
+
+Opening a file inside `vendor/netcdf-fortran/` and pressing `F12` searches only the submodule. Use `M-x repo-grep-set-root` to point repo-grep at the parent repository instead:
+
+```elisp
+M-x repo-grep-set-root  →  select ~/climate-model/
+```
+
+All subsequent searches use that root until you clear it with `M-x repo-grep-clear-root` or restart Emacs.
+
 ### Case sensitivity
 
 By default searches are case-insensitive. In Python codebases this

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -458,6 +458,8 @@ buffer navigate directly to source files."
       (let ((inhibit-read-only t))
         (keep-lines regexp (point-min) (point-max))))))
 
+(defvar grep-mode-map)
+
 (defun repo-grep-setup-keybindings ()
   "Set up optional repo-grep keybindings in grep-mode-map."
   (with-eval-after-load 'grep

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -77,8 +77,8 @@ VC backends are disabled for performance."
   (interactive)
   (setq repo-grep-root
         (read-directory-name "Set project root: "
-                             (or (vc-root-dir) default-directory)
-                             nil t))
+                             (repo-grep--get-root-base)
+                              nil t))
   (message "Project root set to: %s" repo-grep-root))
 
 ;;;###autoload
@@ -92,7 +92,7 @@ VC backends are disabled for performance."
 (defun repo-grep-set-subfolder ()
   "Interactively set `repo-grep-subfolder'."
   (interactive)
-  (let* ((root (or (vc-root-dir) default-directory))
+  (let* ((root (repo-grep--get-root-base))
          (selected-dir (read-directory-name "Select subfolder: " root nil t)))
     (setq repo-grep-subfolder (file-relative-name selected-dir root))
     (message "Search restricted to: %s" repo-grep-subfolder)))
@@ -110,7 +110,7 @@ VC backends are disabled for performance."
   (interactive)
   (unless (derived-mode-p 'dired-mode)
     (error "This command must be run from a Dired buffer"))
-  (let* ((root (or (vc-root-dir) default-directory))
+  (let* ((root (repo-grep--get-root-base))
          (dir (dired-get-file-for-visit)))
     (unless (file-directory-p dir)
       (error "Selected item is not a directory"))
@@ -399,23 +399,24 @@ Requires ripgrep (rg) to be installed and available on PATH."
                                    ".")))
                " " )))
 
-(defun repo-grep--find-folder ()
-  "Determine the folder to run grep in.
+(defun repo-grep--get-root-base ()
+  "Return the effective project root for path calculations.
 Detection priority:
   1. `repo-grep-root' (manual override)
   2. `vc-root-dir' (Git, SVN via Emacs VC)
   3. `.git' directory traversal via `locate-dominating-file'
-  4. `default-directory' as last resort"
-  (let* ((root (or repo-grep-root
-                   (vc-root-dir)
-                   (when-let ((git (locate-dominating-file
-                                    default-directory ".git")))
-                     git)
-                   (when-let ((svn (locate-dominating-file
-                                    default-directory ".svn")))
-                     svn)
-                   default-directory))
-         (folder root))
+  4. `.svn' directory traversal via `locate-dominating-file'
+  5. `default-directory' as last resort"
+  (or repo-grep-root
+      (vc-root-dir)
+      (locate-dominating-file default-directory ".git")
+      (locate-dominating-file default-directory ".svn")
+      default-directory))
+
+(defun repo-grep--find-folder ()
+  "Determine the folder to run grep in.
+Delegates root detection to `repo-grep--get-root-base'."
+  (let ((folder (repo-grep--get-root-base)))
     (when repo-grep-from-folder-above
       (setq folder (expand-file-name ".." folder)))
     (when (and repo-grep-subfolder (not repo-grep-from-folder-above))

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -107,7 +107,7 @@ VC backends are disabled for performance."
 
 ;;;###autoload
 (defun repo-grep-set-subfolder-from-dired ()
-  "Set `repo-grep-subfolder` based on the current directory in a Dired buffer."
+  "Set `repo-grep-subfolder' based on the current directory in a Dired buffer."
   (interactive)
   (unless (derived-mode-p 'dired-mode)
     (error "This command must be run from a Dired buffer"))

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -60,6 +60,34 @@ Ignored when using `repo-grep-multi'."
                  (string :tag "Subfolder name"))
   :group 'repo-grep)
 
+(defcustom repo-grep-root nil
+  "Manual override for the project root directory.
+When non-nil, this path takes precedence over all auto-detection.
+Set interactively with `repo-grep-set-root', clear with
+`repo-grep-clear-root'."
+  :type '(choice (const :tag "Auto-detect" nil)
+                 (directory :tag "Manual root"))
+  :group 'repo-grep)
+
+;;;###autoload
+(defun repo-grep-set-root ()
+  "Manually set the project root, overriding auto-detection.
+Useful when `vc-root-dir' fails in large repositories or when
+VC backends are disabled for performance."
+  (interactive)
+  (setq repo-grep-root
+        (read-directory-name "Set project root: "
+                             (or (vc-root-dir) default-directory)
+                             nil t))
+  (message "Project root set to: %s" repo-grep-root))
+
+;;;###autoload
+(defun repo-grep-clear-root ()
+  "Clear the manual root override and revert to auto-detection."
+  (interactive)
+  (setq repo-grep-root nil)
+  (message "Manual root cleared; reverting to auto-detection"))
+
 ;;;###autoload
 (defun repo-grep-set-subfolder ()
   "Interactively set `repo-grep-subfolder'."
@@ -372,18 +400,30 @@ Requires ripgrep (rg) to be installed and available on PATH."
                " " )))
 
 (defun repo-grep--find-folder ()
-  "Determine the appropriate folder to run grep in.
-Uses Emacs' built-in VCS detection and falls back to `default-directory'.
-If `repo-grep-subfolder' is set and valid, append it to the root."
-  (let ((folder (or (vc-root-dir)
-                    default-directory)))
+  "Determine the folder to run grep in.
+Detection priority:
+  1. `repo-grep-root' (manual override)
+  2. `vc-root-dir' (Git, SVN via Emacs VC)
+  3. `.git' directory traversal via `locate-dominating-file'
+  4. `default-directory' as last resort"
+  (let* ((root (or repo-grep-root
+                   (vc-root-dir)
+                   (when-let ((git (locate-dominating-file
+                                    default-directory ".git")))
+                     git)
+                   (when-let ((svn (locate-dominating-file
+                                    default-directory ".svn")))
+                     svn)
+                   default-directory))
+         (folder root))
     (when repo-grep-from-folder-above
       (setq folder (expand-file-name ".." folder)))
     (when (and repo-grep-subfolder (not repo-grep-from-folder-above))
       (let ((sub (expand-file-name repo-grep-subfolder folder)))
         (if (file-directory-p sub)
             (setq folder sub)
-          (error "Subfolder '%s' does not exist under project root" repo-grep-subfolder))))
+          (error "Subfolder '%s' does not exist under project root"
+                 repo-grep-subfolder))))
     (unless (and folder (file-directory-p folder))
       (error "Could not determine a valid project root folder"))
     folder))

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -1,7 +1,7 @@
 ;;; repo-grep.el --- Project-wide grep search -*- lexical-binding: t; -*-
 
 ;; Author:  Bjoern Hendrik Fock
-;; Version: 1.10.0
+;; Version: 1.11.0.experimental
 ;; License: BSD-3-Clause
 ;; Keywords: tools search grep convenience project
 ;; Package-Requires: ((emacs "27.1"))

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -23,6 +23,7 @@
 ;;
 ;; Features include:
 ;; - VCS-aware project root detection (Git or SVN)
+;; - Manual project root override via `repo-grep-set-root'
 ;; - Case sensitivity and binary file handling options
 ;; - Customisable include/exclude file patterns
 ;; - Clickable results in a standard *grep* buffer

--- a/repo-grep.el
+++ b/repo-grep.el
@@ -1,7 +1,7 @@
 ;;; repo-grep.el --- Project-wide grep search -*- lexical-binding: t; -*-
 
 ;; Author:  Bjoern Hendrik Fock
-;; Version: 1.11.0.experimental
+;; Version: 1.11.0
 ;; License: BSD-3-Clause
 ;; Keywords: tools search grep convenience project
 ;; Package-Requires: ((emacs "27.1"))


### PR DESCRIPTION
**Status: draft — under real-world testing before merge.**

### Problem

In certain setups `vc-root-dir` fails to return the expected project root:
- Large repositories where VC backends have been disabled for performance
- Projects using Git submodules, where opening a file inside a submodule
  causes detection to return the submodule root rather than the parent
  repository

In both cases repo-grep silently searched from the wrong directory with
no way to correct it.

### Changes

- Add `repo-grep-root', a new custom variable for manually overriding
  the project root
- Add `repo-grep-set-root` and `repo-grep-clear-root` for interactive
  control
- Extract all root detection logic into a single helper
  `repo-grep--get-root-base`, used consistently across all functions
  that require the project root
- Add a `locate-dominating-file` fallback for `.git` and `.svn` when
  `vc-root-dir` returns nil
- Document the Git submodule use case in the tutorial

### Usage

If root detection returns the wrong directory, set it manually:

```
M-x repo-grep-set-root
```

Clear the override to revert to auto-detection:

```
M-x repo-grep-clear-root
```

All other behaviour is unchanged.

### Testing

Manually tested on a working setup.